### PR TITLE
Add priority

### DIFF
--- a/priority.go
+++ b/priority.go
@@ -135,7 +135,7 @@ func (pq *priorityQueue) Remove(r *prendezvouz) {
 	heap.Remove((*queue)(pq), r.index)
 }
 
-// PLock implements a FIFO lock with concurrency control, based upon the CoDel algorithm (https://queue.acm.org/detail.cfm?id=2209336).
+// PLock implements a FIFO lock with concurrency control and priority, based upon the CoDel algorithm (https://queue.acm.org/detail.cfm?id=2209336).
 type PLock struct {
 	mu             sync.Mutex
 	target         time.Duration

--- a/priority.go
+++ b/priority.go
@@ -103,6 +103,10 @@ func (pq *priorityQueue) Push(r *prendezvouz) bool {
 		return true
 	}
 
+	if pq.Cap() == 0 {
+		return false
+	}
+
 	// otherwise, we need to check if this takes priority over the lowest element
 	lowestIndex := ((*queue)(pq)).lowestIndex()
 	last := (*pq)[lowestIndex]
@@ -153,7 +157,7 @@ func NewPriority(opts Options) *PLock {
 		target:         opts.TargetLatency,
 		maxOutstanding: int64(opts.MaxOutstanding),
 		maxPending:     int64(opts.MaxPending),
-		waiters:        newQueue(opts.MaxOutstanding),
+		waiters:        newQueue(opts.MaxPending),
 	}
 
 	return &q

--- a/priority.go
+++ b/priority.go
@@ -1,0 +1,317 @@
+package codel
+
+import (
+	"container/heap"
+	"context"
+	"math"
+	"sync"
+	"time"
+)
+
+const maxInt = int((^uint(0)) >> 1)
+
+// prendezvouz is for returning context to the calling goroutine
+type prendezvouz struct {
+	priority     int
+	index        int
+	enqueuedTime time.Time
+	errChan      chan error
+}
+
+func (r prendezvouz) Drop() {
+	select {
+	case r.errChan <- Dropped:
+	default:
+	}
+}
+
+func (r prendezvouz) Signal() {
+	close(r.errChan)
+}
+
+type queue []*prendezvouz
+
+func (pq queue) Len() int { return len(pq) }
+
+func (pq queue) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return pq[i].priority > pq[j].priority
+}
+
+func (pq queue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *queue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*prendezvouz)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *queue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return item
+}
+
+func (pq *queue) lowestIndex() int {
+	old := *pq
+	n := len(old)
+	index := n / 2
+
+	lowestIndex := index
+	priority := maxInt
+
+	for i := index; i < n; i++ {
+		if old[i].priority < priority {
+			lowestIndex = i
+			priority = old[i].priority
+		}
+	}
+
+	return lowestIndex
+}
+
+type priorityQueue queue
+
+func newQueue(capacity int) priorityQueue {
+	return priorityQueue(make([]*prendezvouz, 0, capacity))
+}
+
+func (pq *priorityQueue) Len() int {
+	return len(*pq)
+}
+
+func (pq *priorityQueue) Cap() int {
+	return cap(*pq)
+}
+
+func (pq *priorityQueue) push(r *prendezvouz) {
+	heap.Push((*queue)(pq), r)
+}
+
+func (pq *priorityQueue) Push(r *prendezvouz) bool {
+	// If we're under capacity, push it to the queue
+	if pq.Len() < pq.Cap() {
+		pq.push(r)
+		return true
+	}
+
+	// otherwise, we need to check if this takes priority over the lowest element
+	lowestIndex := ((*queue)(pq)).lowestIndex()
+	last := (*pq)[lowestIndex]
+	if last.priority < r.priority {
+		(*pq)[lowestIndex] = r
+		heap.Fix((*queue)(pq), lowestIndex)
+
+		last.Drop()
+
+		return true
+	}
+
+	return false
+
+}
+
+func (pq *priorityQueue) Pop() *prendezvouz {
+	if (*queue)(pq).Len() <= 0 {
+		return nil
+	}
+	r := heap.Pop((*queue)(pq)).(*prendezvouz)
+	return r
+}
+
+func (pq *priorityQueue) Remove(r *prendezvouz) {
+	heap.Remove((*queue)(pq), r.index)
+}
+
+// PLock implements a FIFO lock with concurrency control, based upon the CoDel algorithm (https://queue.acm.org/detail.cfm?id=2209336).
+type PLock struct {
+	mu             sync.Mutex
+	target         time.Duration
+	firstAboveTime time.Time
+	dropNext       time.Time
+
+	droppedCount int64
+	dropping     bool
+
+	waiters    priorityQueue
+	maxPending int64
+
+	outstanding    int64
+	maxOutstanding int64
+}
+
+func NewPriority(opts Options) *PLock {
+	q := PLock{
+		target:         opts.TargetLatency,
+		maxOutstanding: int64(opts.MaxOutstanding),
+		maxPending:     int64(opts.MaxPending),
+		waiters:        newQueue(opts.MaxOutstanding),
+	}
+
+	return &q
+}
+
+// Acquire a PLock with FIFO ordering, respecting the context. Returns an error it fails to acquire.
+func (l *PLock) Acquire(ctx context.Context, priority int) error {
+	l.mu.Lock()
+
+	// Fast path if we are unblocked.
+	if l.outstanding < l.maxOutstanding && l.waiters.Len() == 0 {
+		l.outstanding++
+		l.mu.Unlock()
+		return nil
+	}
+
+	// If our queue is full, drop
+	if int64(l.waiters.Len()) == l.maxPending {
+		l.externalDrop()
+		l.mu.Unlock()
+		return Dropped
+	}
+
+	r := prendezvouz{
+		priority:     priority,
+		enqueuedTime: time.Now(),
+		errChan:      make(chan error),
+	}
+
+	l.waiters.Push(&r)
+	l.mu.Unlock()
+
+	select {
+
+	case err := <-r.errChan:
+		return err
+
+	case <-ctx.Done():
+		err := ctx.Err()
+
+		l.mu.Lock()
+
+		select {
+		case err = <-r.errChan:
+		default:
+			l.waiters.Remove(&r)
+			l.externalDrop()
+		}
+
+		l.mu.Unlock()
+
+		return err
+	}
+}
+
+// Release a previously acquired lock.
+func (l *PLock) Release() {
+	l.mu.Lock()
+	l.outstanding--
+	if l.outstanding < 0 {
+		l.mu.Unlock()
+		panic("lock: bad release")
+	}
+
+	l.deque()
+
+	l.mu.Unlock()
+
+}
+
+// Adjust the time based upon interval / sqrt(droppedCount)
+func (l *PLock) controlLaw(t time.Time) time.Time {
+	return t.Add(time.Duration(float64(interval) / math.Sqrt(float64(l.droppedCount))))
+}
+
+// Pull a single instance off the queue. This should be
+func (l *PLock) doDeque(now time.Time) (r *prendezvouz, ok bool, okToDrop bool) {
+	r = l.waiters.Pop()
+
+	if r == nil {
+		return r, false, false
+	}
+
+	sojurnDuration := now.Sub(r.enqueuedTime)
+
+	if sojurnDuration < l.target || l.waiters.Len() == 0 {
+		l.firstAboveTime = time.Time{}
+	} else if (l.firstAboveTime == time.Time{}) {
+		l.firstAboveTime = now.Add(interval)
+	} else if now.After(l.firstAboveTime) {
+		okToDrop = true
+	}
+
+	return r, true, okToDrop
+
+}
+
+// Signal that we couldn't write to the queue
+func (l *PLock) externalDrop() {
+	l.dropping = true
+	l.droppedCount++
+	l.dropNext = l.controlLaw(l.dropNext)
+}
+
+// Pull instances off the queue until we no longer drop
+func (l *PLock) deque() {
+	now := time.Now()
+
+	rendezvouz, ok, okToDrop := l.doDeque(now)
+
+	// The queue has no entries, so return
+	if !ok {
+		return
+	}
+
+	if !okToDrop {
+		l.dropping = false
+		l.outstanding++
+		rendezvouz.Signal()
+		return
+	}
+
+	if l.dropping {
+		for now.After(l.dropNext) && l.dropping {
+			rendezvouz.Drop()
+			rendezvouz, ok, okToDrop = l.doDeque(now)
+
+			if !ok {
+				return
+			}
+
+			l.droppedCount++
+
+			if !okToDrop {
+				l.dropping = false
+			} else {
+				l.dropNext = l.controlLaw(l.dropNext)
+			}
+		}
+	} else if now.Sub(l.dropNext) < interval || now.Sub(l.firstAboveTime) >= interval {
+		rendezvouz.Drop()
+		rendezvouz, ok, _ = l.doDeque(now)
+
+		if !ok {
+			return
+		}
+
+		l.dropping = true
+
+		if l.droppedCount > 2 {
+			l.droppedCount -= 2
+		} else {
+			l.droppedCount = 1
+		}
+
+		l.dropNext = l.controlLaw(now)
+	}
+
+	l.outstanding++
+	rendezvouz.Signal()
+}

--- a/priority_test.go
+++ b/priority_test.go
@@ -17,6 +17,28 @@ func msToWait(perSec int64) time.Duration {
 	return time.Duration(ms * float64(time.Millisecond))
 }
 
+func TestPriority(t *testing.T) {
+	t.Run("It should drop if zero enqueued", func(t *testing.T) {
+		limiter := NewPriority(Options{
+			MaxPending:     0,
+			MaxOutstanding: 1,
+			TargetLatency:  10 * time.Millisecond,
+		})
+
+		err := limiter.Acquire(context.Background(), 0)
+		if err != nil {
+			t.Errorf("Expected nil err: %s", err)
+			return
+		}
+
+		err = limiter.Acquire(context.Background(), 0)
+		if err == nil {
+			t.Errorf("Expected non-nil err: %s", err)
+		}
+
+	})
+}
+
 // Simulate 3 priorities of 1000 reqs/second each, fighting for a
 // process that can process 15 concurrent at 100 reqs/second. This
 // should be enough capacity for the highest priority, The middle

--- a/priority_test.go
+++ b/priority_test.go
@@ -1,0 +1,79 @@
+package codel
+
+import (
+	"context"
+	"flag"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var sim = flag.Bool("sim", false, "run simulation test")
+
+func msToWait(perSec int64) time.Duration {
+	ms := rand.ExpFloat64() / (float64(perSec) / 1000)
+	return time.Duration(ms * float64(time.Millisecond))
+}
+
+// Simulate 3 priorities of 1000 reqs/second each, fighting for a
+// process that can process 15 concurrent at 100 reqs/second. This
+// should be enough capacity for the highest priority, The middle
+// priority seeing partial unavailability, and the lowest priority
+// seeing near full unavailability
+func TestConcurrentSimulation(t *testing.T) {
+	if !(*sim) {
+		t.Log("Skipping sim since -sim not passed")
+		t.Skip()
+	}
+
+	wg := sync.WaitGroup{}
+
+	limiter := NewPriority(Options{
+		MaxPending:     100,
+		MaxOutstanding: 15,
+		TargetLatency:  10 * time.Millisecond,
+	})
+
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+
+		priority := 10 * i
+		go func() {
+			defer wg.Done()
+
+			inner := sync.WaitGroup{}
+
+			success := int64(0)
+			error := int64(0)
+
+			for i := 0; i < 1000; i++ {
+				inner.Add(1)
+				time.Sleep(msToWait(1000))
+
+				go func() {
+					defer inner.Done()
+
+					err := limiter.Acquire(context.Background(), priority)
+					if err != nil {
+						atomic.AddInt64(&error, 1)
+						return
+					}
+					defer limiter.Release()
+
+					time.Sleep(msToWait(100))
+					atomic.AddInt64(&success, 1)
+
+				}()
+			}
+
+			inner.Wait()
+			t.Logf("priority=%d success=%f dropped=%f", priority, (float64(success) / 1000), float64(error)/1000)
+
+		}()
+	}
+
+	wg.Wait()
+
+}


### PR DESCRIPTION
Instead of using a list to queue requests, use a priority queue. This allows us to prioritize higher priority traffic, and only drop lower priority traffic. 