### PR TITLE
 Fix queue indexing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-  - "1.11.x"
-  - "1.12.x"
+  - "1.14.x"
   - master
 
-script: go test -v . -bench . -benchmem
+script:
+  - go test -v . -race -sim
+  - go test -v . -bench . -benchmem

--- a/priority.go
+++ b/priority.go
@@ -1,7 +1,6 @@
 package codel
 
 import (
-	"container/heap"
 	"context"
 	"math"
 	"sync"
@@ -27,112 +26,6 @@ func (r prendezvouz) Drop() {
 
 func (r prendezvouz) Signal() {
 	close(r.errChan)
-}
-
-type queue []*prendezvouz
-
-func (pq queue) Len() int { return len(pq) }
-
-func (pq queue) Less(i, j int) bool {
-	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
-	return pq[i].priority > pq[j].priority
-}
-
-func (pq queue) Swap(i, j int) {
-	pq[i], pq[j] = pq[j], pq[i]
-	pq[i].index = i
-	pq[j].index = j
-}
-
-func (pq *queue) Push(x interface{}) {
-	n := len(*pq)
-	item := x.(*prendezvouz)
-	item.index = n
-	*pq = append(*pq, item)
-}
-
-func (pq *queue) Pop() interface{} {
-	old := *pq
-	n := len(old)
-	item := old[n-1]
-	item.index = -1 // for safety
-	*pq = old[0 : n-1]
-	return item
-}
-
-func (pq *queue) lowestIndex() int {
-	old := *pq
-	n := len(old)
-	index := n / 2
-
-	lowestIndex := index
-	priority := maxInt
-
-	for i := index; i < n; i++ {
-		if old[i].priority < priority {
-			lowestIndex = i
-			priority = old[i].priority
-		}
-	}
-
-	return lowestIndex
-}
-
-type priorityQueue queue
-
-func newQueue(capacity int) priorityQueue {
-	return priorityQueue(make([]*prendezvouz, 0, capacity))
-}
-
-func (pq *priorityQueue) Len() int {
-	return len(*pq)
-}
-
-func (pq *priorityQueue) Cap() int {
-	return cap(*pq)
-}
-
-func (pq *priorityQueue) push(r *prendezvouz) {
-	heap.Push((*queue)(pq), r)
-}
-
-func (pq *priorityQueue) Push(r *prendezvouz) bool {
-	// If we're under capacity, push it to the queue
-	if pq.Len() < pq.Cap() {
-		pq.push(r)
-		return true
-	}
-
-	if pq.Cap() == 0 {
-		return false
-	}
-
-	// otherwise, we need to check if this takes priority over the lowest element
-	lowestIndex := ((*queue)(pq)).lowestIndex()
-	last := (*pq)[lowestIndex]
-	if last.priority < r.priority {
-		(*pq)[lowestIndex] = r
-		heap.Fix((*queue)(pq), lowestIndex)
-
-		last.Drop()
-
-		return true
-	}
-
-	return false
-
-}
-
-func (pq *priorityQueue) Pop() *prendezvouz {
-	if (*queue)(pq).Len() <= 0 {
-		return nil
-	}
-	r := heap.Pop((*queue)(pq)).(*prendezvouz)
-	return r
-}
-
-func (pq *priorityQueue) Remove(r *prendezvouz) {
-	heap.Remove((*queue)(pq), r.index)
 }
 
 // PLock implements a FIFO lock with concurrency control and priority, based upon the CoDel algorithm (https://queue.acm.org/detail.cfm?id=2209336).
@@ -199,6 +92,7 @@ func (l *PLock) Acquire(ctx context.Context, priority int) error {
 		err := ctx.Err()
 
 		l.mu.Lock()
+		defer l.mu.Unlock()
 
 		select {
 		case err = <-r.errChan:
@@ -206,8 +100,6 @@ func (l *PLock) Acquire(ctx context.Context, priority int) error {
 			l.waiters.Remove(&r)
 			l.externalDrop()
 		}
-
-		l.mu.Unlock()
 
 		return err
 	}
@@ -234,12 +126,12 @@ func (l *PLock) controlLaw(t time.Time) time.Time {
 }
 
 // Pull a single instance off the queue. This should be
-func (l *PLock) doDeque(now time.Time) (r *prendezvouz, ok bool, okToDrop bool) {
-	r = l.waiters.Pop()
-
-	if r == nil {
+func (l *PLock) doDeque(now time.Time) (r prendezvouz, ok bool, okToDrop bool) {
+	if l.waiters.Empty() {
 		return r, false, false
 	}
+
+	r = l.waiters.Pop()
 
 	sojurnDuration := now.Sub(r.enqueuedTime)
 

--- a/queue.go
+++ b/queue.go
@@ -87,9 +87,13 @@ func (pq *priorityQueue) Push(r *prendezvouz) bool {
 	last := (*pq)[lowestIndex]
 	if last.priority < r.priority {
 		(*pq)[lowestIndex] = r
+
+		// Fix the index
 		r.index = lowestIndex
 		heap.Fix((*queue)(pq), lowestIndex)
 
+		// For safety
+		last.index = -1
 		last.Drop()
 
 		return true

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,113 @@
+package codel
+
+import (
+	"container/heap"
+)
+
+type queue []*prendezvouz
+
+func (pq queue) Len() int { return len(pq) }
+
+func (pq queue) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return pq[i].priority > pq[j].priority
+}
+
+func (pq queue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *queue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*prendezvouz)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *queue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return item
+}
+
+func (pq *queue) lowestIndex() int {
+	old := *pq
+	n := len(old)
+	index := n / 2
+
+	lowestIndex := index
+	priority := maxInt
+
+	for i := index; i < n; i++ {
+		if old[i].priority < priority {
+			lowestIndex = i
+			priority = old[i].priority
+		}
+	}
+
+	return lowestIndex
+}
+
+type priorityQueue queue
+
+func newQueue(capacity int) priorityQueue {
+	return priorityQueue(make([]*prendezvouz, 0, capacity))
+}
+
+func (pq *priorityQueue) Len() int {
+	return len(*pq)
+}
+
+func (pq *priorityQueue) Cap() int {
+	return cap(*pq)
+}
+
+func (pq *priorityQueue) push(r *prendezvouz) {
+	heap.Push((*queue)(pq), r)
+}
+
+func (pq *priorityQueue) Push(r *prendezvouz) bool {
+	// If we're under capacity, push it to the queue
+	if pq.Len() < pq.Cap() {
+		pq.push(r)
+		return true
+	}
+
+	if pq.Cap() == 0 {
+		return false
+	}
+
+	// otherwise, we need to check if this takes priority over the lowest element
+	lowestIndex := ((*queue)(pq)).lowestIndex()
+	last := (*pq)[lowestIndex]
+	if last.priority < r.priority {
+		(*pq)[lowestIndex] = r
+		r.index = lowestIndex
+		heap.Fix((*queue)(pq), lowestIndex)
+
+		last.Drop()
+
+		return true
+	}
+
+	return false
+
+}
+
+func (pq *priorityQueue) Empty() bool {
+	return len(*pq) <= 0
+}
+
+func (pq *priorityQueue) Pop() prendezvouz {
+	r := heap.Pop((*queue)(pq)).(*prendezvouz)
+	return *r
+}
+
+func (pq *priorityQueue) Remove(r *prendezvouz) {
+	heap.Remove((*queue)(pq), r.index)
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,0 +1,129 @@
+package codel
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flyingmutant/rapid"
+)
+
+type queueMachine struct {
+	q *priorityQueue // queue being tested
+	n int            // maximum queue size
+}
+
+// Init is an action for initializing  a queueMachine instance.
+func (m *queueMachine) Init(t *rapid.T) {
+	n := rapid.IntRange(1, 3).Draw(t, "n").(int)
+	q := newQueue(n)
+	m.q = &q
+	m.n = n
+}
+
+// Model of Push
+func (m *queueMachine) Push(t *rapid.T) {
+	r := prendezvouz{
+		priority:     rapid.Int().Draw(t, "priority").(int),
+		enqueuedTime: time.Now(),
+		errChan:      make(chan error, 1),
+	}
+
+	m.q.Push(&r)
+}
+
+// Model of Remove
+func (m *queueMachine) Remove(t *rapid.T) {
+	if m.q.Empty() {
+		t.Skip("empty")
+	}
+
+	r := (*m.q)[rapid.IntRange(0, m.q.Len()-1).Draw(t, "i").(int)]
+	m.q.Remove(r)
+}
+
+// Model of Drop
+func (m *queueMachine) Drop(t *rapid.T) {
+	if m.q.Empty() {
+		t.Skip("empty")
+	}
+
+	r := (*m.q)[rapid.IntRange(0, m.q.Len()-1).Draw(t, "i").(int)]
+	r.Drop()
+}
+
+// Model of Signal
+func (m *queueMachine) Pop(t *rapid.T) {
+	if m.q.Empty() {
+		t.Skip("empty")
+	}
+
+	r := m.q.Pop()
+	r.Signal()
+}
+
+// validate that invariants hold
+func (m *queueMachine) Check(t *rapid.T) {
+	if m.q.Len() > m.q.Cap() {
+		t.Fatalf("queue over capacity: %v vs expected %v", m.q.Len(), m.q.Cap())
+	}
+
+	for i, r := range *m.q {
+		if r.index != i {
+			t.Fatalf("illegal index: expected %d, got %+v ", i, r)
+		}
+	}
+
+}
+
+func TestPriorityQueue(t *testing.T) {
+	t.Run("It should meet invariants", func(t *testing.T) {
+		rapid.Check(t, rapid.Run(&queueMachine{}))
+	})
+
+	t.Run("It should not panic", func(t *testing.T) {
+		q := newQueue(3)
+
+		mu := sync.Mutex{}
+
+		wg := sync.WaitGroup{}
+
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			priority := i
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("Failed with panic %+v", r)
+					}
+				}()
+
+				for i := 0; i < 1000; i++ {
+					r := prendezvouz{
+						priority:     priority,
+						enqueuedTime: time.Now(),
+						errChan:      make(chan error, 1),
+					}
+
+					mu.Lock()
+					pushed := q.Push(&r)
+					mu.Unlock()
+
+					if !pushed {
+						continue
+					}
+
+					mu.Lock()
+					q.Remove(&r)
+					mu.Unlock()
+				}
+
+			}()
+		}
+
+		wg.Wait()
+
+	})
+
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -115,7 +115,9 @@ func TestPriorityQueue(t *testing.T) {
 					}
 
 					mu.Lock()
-					q.Remove(&r)
+					if r.index >= 0 {
+						q.Remove(&r)
+					}
 					mu.Unlock()
 				}
 


### PR DESCRIPTION
When pushing to a full queue, the index wasn't properly tracked. This
can result in invalid removals.